### PR TITLE
Handle Pushes from Pushwoosh on Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -62,7 +62,8 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<framework src="com.google.firebase:firebase-perf:+" />
 	</platform>
 
-	<platform name="ios">
+	<!-- @author:david we don't use Firebase on iOS -->
+	<!-- <platform name="ios">
 		<hook type="after_plugin_install" src="scripts/ios/after_plugin_install.js" />
 		<hook type="before_plugin_uninstall" src="scripts/ios/before_plugin_uninstall.js" />
 
@@ -109,7 +110,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<framework custom="true" src="src/ios/Firebase/RemoteConfig/Protobuf.framework" />
 		<framework custom="true" src="src/ios/Firebase/RemoteConfig/FirebaseRemoteConfig.framework" />
 		<framework custom="true" src="src/ios/Firebase/RemoteConfig/FirebaseABTesting.framework" />
-	</platform>
+	</platform> -->
 
 	<platform name="browser">
 		<js-module name="FirebasePlugin" src="www/firebase-browser.js">

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -89,6 +89,27 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
             if (TextUtils.isEmpty(text)) {
                 text = data.get("body");
             }
+
+            /**
+             * @custom:zenput Due to misalignments between the data that Pushwoosh sends and what this plugin looks for,
+             * we need to shuffle some data values around.
+             */
+
+            String pushwooshHeader = ""; // sometimes Pushwoosh sends the title as "header"
+
+            // Pushwoosh sends the body as 'title'
+            if (!TextUtils.isEmpty(title) && TextUtils.isEmpty(text)) {
+                text = title;
+                title = pushwooshHeader;
+            }
+
+            if (!TextUtils.isEmpty(pushwooshHeader)) {
+                title = pushwooshHeader;
+            }
+
+            if (TextUtils.isEmpty(title)) {
+                title = "Zenput";
+            }
         }
 
         if (TextUtils.isEmpty(id)) {


### PR DESCRIPTION
This PR:

- Remaps the notification payload keys to match those sent by Pushwoosh
    - "header" --> "title" and "title" --> "text"
- Sets a default notification title of "Zenput" if none is sent
- Disables the plugin for iOS since we don't currently use it and it was causing a crash.