### PR TITLE
[MCI 53] Lock down firebase versions 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,11 +49,11 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
-		<framework src="com.google.android.gms:play-services-tagmanager:+" />
-		<framework src="com.google.firebase:firebase-core:+" />
-		<framework src="com.google.firebase:firebase-messaging:+" />
-		<framework src="com.google.firebase:firebase-config:+" />
-		<framework src="com.google.firebase:firebase-perf:+" />
+		<framework src="com.google.android.gms:play-services-tagmanager:16.0.8" />
+		<framework src="com.google.firebase:firebase-core:16.0.8" />
+		<framework src="com.google.firebase:firebase-messaging:17.5.0" />
+		<framework src="com.google.firebase:firebase-config:16.4.1" />
+		<framework src="com.google.firebase:firebase-perf:16.2.4" />
 	</platform>
 
 	<!-- @author:david we don't use Firebase on iOS -->

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     compile 'me.leolin:ShortcutBadger:1.1.4@aar'
-    compile 'com.google.firebase:firebase-auth:+'
+    compile 'com.google.firebase:firebase-auth:16.2.0'
     compile('com.crashlytics.sdk.android:crashlytics:2.9.1@aar') {
        transitive = true
     }


### PR DESCRIPTION
Google is constantly updating firebase and some other libraries, which can cause incompatibility issues in the future or problems like [MCI-53](https://github.com/zenput/zenput/pull/3830).

`com.google.firebase` libraries and `com.google.android.gms:play-services-tagmanager` have been downgraded to a stable version.